### PR TITLE
Initial operation definition/handler abstraction

### DIFF
--- a/nexus-sdk/build.gradle
+++ b/nexus-sdk/build.gradle
@@ -5,11 +5,12 @@ plugins {
 }
 
 dependencies {
-    compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+    compileOnly 'org.jspecify:jspecify:1.+'
 
     testImplementation libs.junit.jupiter
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testCompileOnly 'org.jspecify:jspecify:1.+'
 }
 
 java {

--- a/nexus-sdk/src/main/java/io/nexusrpc/FailureInfo.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/FailureInfo.java
@@ -7,10 +7,10 @@ import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /** Information about an operation failure. */
-public class OperationFailure {
+public class FailureInfo {
   private final String message;
   private final Map<String, String> metadata;
-  private final @Nullable Object details;
+  private final @Nullable String detailsJson;
 
   /** Create a builder for an operation failure. */
   public static Builder newBuilder() {
@@ -18,14 +18,14 @@ public class OperationFailure {
   }
 
   /** Create a builder for an operation failure from an existing operation failure. */
-  public static Builder newBuilder(OperationFailure failure) {
+  public static Builder newBuilder(FailureInfo failure) {
     return new Builder(failure);
   }
 
-  private OperationFailure(String message, Map<String, String> metadata, @Nullable Object details) {
+  private FailureInfo(String message, Map<String, String> metadata, @Nullable String detailsJson) {
     this.message = message;
     this.metadata = metadata;
-    this.details = details;
+    this.detailsJson = detailsJson;
   }
 
   /** Failure message. */
@@ -39,23 +39,23 @@ public class OperationFailure {
   }
 
   /** Failure details. */
-  public @Nullable Object getDetails() {
-    return details;
+  public @Nullable String getDetailsJson() {
+    return detailsJson;
   }
 
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    OperationFailure that = (OperationFailure) o;
+    FailureInfo that = (FailureInfo) o;
     return Objects.equals(message, that.message)
         && Objects.equals(metadata, that.metadata)
-        && Objects.equals(details, that.details);
+        && Objects.equals(detailsJson, that.detailsJson);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(message, metadata, details);
+    return Objects.hash(message, metadata, detailsJson);
   }
 
   @Override
@@ -67,7 +67,7 @@ public class OperationFailure {
         + ", metadata="
         + metadata
         + ", details="
-        + details
+        + detailsJson
         + '}';
   }
 
@@ -75,16 +75,16 @@ public class OperationFailure {
   public static class Builder {
     private @Nullable String message;
     private final Map<String, String> metadata;
-    private @Nullable Object details;
+    private @Nullable String detailsJson;
 
     private Builder() {
       metadata = new HashMap<>();
     }
 
-    private Builder(OperationFailure failure) {
+    private Builder(FailureInfo failure) {
       message = failure.message;
       metadata = new HashMap<>(failure.metadata);
-      details = failure.details;
+      detailsJson = failure.detailsJson;
     }
 
     /** Set message, required. */
@@ -105,16 +105,16 @@ public class OperationFailure {
     }
 
     /** Set details. */
-    public Builder setDetails(@Nullable Object details) {
-      this.details = details;
+    public Builder setDetailsJson(@Nullable String detailsJson) {
+      this.detailsJson = detailsJson;
       return this;
     }
 
     /** Build the operation failure. */
-    public OperationFailure build() {
+    public FailureInfo build() {
       Objects.requireNonNull(message, "Message required");
-      return new OperationFailure(
-          message, Collections.unmodifiableMap(new HashMap<>(metadata)), details);
+      return new FailureInfo(
+          message, Collections.unmodifiableMap(new HashMap<>(metadata)), detailsJson);
     }
   }
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/Operation.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/Operation.java
@@ -6,16 +6,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Operations are interface methods defined on {@link Service} interfaces. This annotation is not
- * inherited, so it must be on any overridden signature in any sub-interface with the same values or
- * an error will occur. Similarly, an error will occur if an implementation has multiple operation
- * definitions of the same name with different signatures.
+ * Operations are interface methods defined on {@link Service} interfaces.
  *
- * <p>Return type is {@link java.util.concurrent.Future} for async operations, or any other value
- * for synchronous operations. The operation may accept no more than one parameter. All types must
- * be serializable.
+ * <p>This annotation is not inherited, so it must be on any overridden signature in any
+ * sub-interface with the same values or an error will occur. Similarly, an error will occur if an
+ * implementation has multiple operation definitions of the same name with different signatures.
  *
- * <p>Implementation details of an operation are not yet defined.
+ * <p>An operation can only define zero or one parameter that supports conversion. The return type
+ * can be <c>void</c> or a type that supports conversion. An operation declaration cannot have a
+ * <c>throws</c> clause. An operation cannot have a default implementation and cannot be static on
+ * the interface.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationDefinition.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationDefinition.java
@@ -1,48 +1,66 @@
 package io.nexusrpc;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Objects;
-import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 
+/** Definition of an operation on a service. */
 public class OperationDefinition {
-  public static OperationDefinition fromMethod(Method method) {
-    throw new UnsupportedOperationException("TODO");
+  static OperationDefinition fromMethod(Method method) {
+    Operation operation = method.getDeclaredAnnotation(Operation.class);
+    if (operation == null) {
+      throw new IllegalArgumentException("Missing @Operation annotation");
+    } else if (method.getParameterCount() > 1) {
+      throw new IllegalArgumentException("Can have no more than one parameter");
+    } else if (method.getTypeParameters().length > 0) {
+      throw new IllegalArgumentException("Cannot be generic");
+    } else if (method.getExceptionTypes().length > 0) {
+      throw new IllegalArgumentException("Cannot have throws clause");
+    } else if (method.isDefault() && !method.isSynthetic()) {
+      throw new IllegalArgumentException("Cannot have default implementation");
+    } else if (Modifier.isStatic(method.getModifiers())) {
+      throw new IllegalArgumentException("Cannot be static");
+    }
+    return newBuilder()
+        .setName(operation.name().isEmpty() ? method.getName() : operation.name())
+        .setInputType(method.getParameterCount() == 0 ? Void.TYPE : method.getParameterTypes()[0])
+        .setOutputType(method.getGenericReturnType())
+        .build();
   }
 
+  /** Create a builder for an operation definition. */
   public static Builder newBuilder() {
     return new Builder();
   }
 
+  /** Create a builder for an operation definition from an existing operation definition. */
   public static Builder newBuilder(OperationDefinition definition) {
     return new Builder(definition);
   }
 
   private final String name;
-  private final boolean async;
-  private final Optional<Type> inputType;
+  private final Type inputType;
   private final Type outputType;
 
-  private OperationDefinition(
-      String name, boolean async, Optional<Type> inputType, Type outputType) {
+  private OperationDefinition(String name, Type inputType, Type outputType) {
     this.name = name;
-    this.async = async;
     this.inputType = inputType;
     this.outputType = outputType;
   }
 
+  /** Operation name. */
   public String getName() {
     return name;
   }
 
-  public boolean isAsync() {
-    return async;
-  }
-
-  public Optional<Type> getInputType() {
+  /** Input type. Will be {@link Void#TYPE} if no input type. */
+  public Type getInputType() {
     return inputType;
   }
 
+  /** Output type. Will be {@link Void#TYPE} if void return. */
   public Type getOutputType() {
     return outputType;
   }
@@ -52,15 +70,14 @@ public class OperationDefinition {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     OperationDefinition that = (OperationDefinition) o;
-    return async == that.async
-        && Objects.equals(name, that.name)
+    return Objects.equals(name, that.name)
         && Objects.equals(inputType, that.inputType)
         && Objects.equals(outputType, that.outputType);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, async, inputType, outputType);
+    return Objects.hash(name, inputType, outputType);
   }
 
   @Override
@@ -69,8 +86,6 @@ public class OperationDefinition {
         + "name='"
         + name
         + '\''
-        + ", async="
-        + async
         + ", inputType="
         + inputType
         + ", outputType="
@@ -78,42 +93,44 @@ public class OperationDefinition {
         + '}';
   }
 
+  /** Builder for an operation definition. */
   public static class Builder {
-    private String name;
-    private boolean async;
-    private Optional<Type> inputType;
-    private Type outputType;
+    @Nullable private String name;
+    @Nullable private Type inputType;
+    @Nullable private Type outputType;
 
     private Builder() {}
 
     private Builder(OperationDefinition definition) {
-      if (definition == null) {
-        return;
-      }
-      this.name = definition.name;
-      this.async = definition.async;
-      this.inputType = definition.inputType;
-      this.outputType = definition.outputType;
+      name = definition.name;
+      inputType = definition.inputType;
+      outputType = definition.outputType;
     }
 
-    public void setName(String name) {
+    /** Set operation name, required. */
+    public Builder setName(String name) {
       this.name = name;
+      return this;
     }
 
-    public void setAsync(boolean async) {
-      this.async = async;
-    }
-
-    public void setInputType(Optional<Type> inputType) {
+    /** Set input type, required. */
+    public Builder setInputType(Type inputType) {
       this.inputType = inputType;
+      return this;
     }
 
-    public void setOutputType(Type outputType) {
+    /** Set output type, required. */
+    public Builder setOutputType(Type outputType) {
       this.outputType = outputType;
+      return this;
     }
 
+    /** Build the operation definition. */
     public OperationDefinition build() {
-      return new OperationDefinition(name, async, inputType, outputType);
+      Objects.requireNonNull(name, "Name required");
+      Objects.requireNonNull(inputType, "Input type required");
+      Objects.requireNonNull(outputType, "Output type required");
+      return new OperationDefinition(name, inputType, outputType);
     }
   }
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationFailure.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationFailure.java
@@ -1,0 +1,120 @@
+package io.nexusrpc;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+/** Information about an operation failure. */
+public class OperationFailure {
+  private final String message;
+  private final Map<String, String> metadata;
+  private final @Nullable Object details;
+
+  /** Create a builder for an operation failure. */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /** Create a builder for an operation failure from an existing operation failure. */
+  public static Builder newBuilder(OperationFailure failure) {
+    return new Builder(failure);
+  }
+
+  private OperationFailure(String message, Map<String, String> metadata, @Nullable Object details) {
+    this.message = message;
+    this.metadata = metadata;
+    this.details = details;
+  }
+
+  /** Failure message. */
+  public String getMessage() {
+    return message;
+  }
+
+  /** Failure metadata. */
+  public Map<String, String> getMetadata() {
+    return metadata;
+  }
+
+  /** Failure details. */
+  public @Nullable Object getDetails() {
+    return details;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OperationFailure that = (OperationFailure) o;
+    return Objects.equals(message, that.message)
+        && Objects.equals(metadata, that.metadata)
+        && Objects.equals(details, that.details);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message, metadata, details);
+  }
+
+  @Override
+  public String toString() {
+    return "OperationFailure{"
+        + "message='"
+        + message
+        + '\''
+        + ", metadata="
+        + metadata
+        + ", details="
+        + details
+        + '}';
+  }
+
+  /** Builder for an operation failure. */
+  public static class Builder {
+    private @Nullable String message;
+    private final Map<String, String> metadata;
+    private @Nullable Object details;
+
+    private Builder() {
+      metadata = new HashMap<>();
+    }
+
+    private Builder(OperationFailure failure) {
+      message = failure.message;
+      metadata = new HashMap<>(failure.metadata);
+      details = failure.details;
+    }
+
+    /** Set message, required. */
+    public Builder setMessage(String message) {
+      this.message = message;
+      return this;
+    }
+
+    /** Get metadata to mutate. */
+    public Map<String, String> getMetadata() {
+      return metadata;
+    }
+
+    /** Add a single metadata key/value. */
+    public Builder putMetadata(String key, String value) {
+      metadata.put(key, value);
+      return this;
+    }
+
+    /** Set details. */
+    public Builder setDetails(@Nullable Object details) {
+      this.details = details;
+      return this;
+    }
+
+    /** Build the operation failure. */
+    public OperationFailure build() {
+      Objects.requireNonNull(message, "Message required");
+      return new OperationFailure(
+          message, Collections.unmodifiableMap(new HashMap<>(metadata)), details);
+    }
+  }
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationHandler.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationHandler.java
@@ -1,0 +1,228 @@
+package io.nexusrpc;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Handler for an operation.
+ *
+ * <p>An instance of this must be returned from an {@link OperationImpl} annotated method in a
+ * {@link ServiceImpl}. Simple synchronous operations can use {@link #sync}, more complex or
+ * asynchronous operations can manually implement this interface.
+ *
+ * @param <T> The parameter type of the operation. This can be {@link Void} for no parameter.
+ * @param <R> the return type of the operation. This can be {@link Void} for no return.
+ */
+public interface OperationHandler<T, R> {
+  /**
+   * Create an operation handler for a synchronous operation backed by the given function. This
+   * function will be called for each operation invocation. All other calls to the operation are not
+   * supported.
+   */
+  static <T, R> OperationHandler<T, R> sync(BiFunction<StartContext, @Nullable T, R> func) {
+    return new OperationHandler<T, R>() {
+      @Override
+      public StartResult<R> start(StartContext ctx, @Nullable T param) {
+        return StartResult.sync(func.apply(ctx, param));
+      }
+
+      @Override
+      public R fetchResult(FetchResultContext ctx) {
+        throw new UnsupportedOperationException("Not supported on sync operation");
+      }
+
+      @Override
+      public OperationInfo fetchInfo(FetchInfoContext ctx) {
+        throw new UnsupportedOperationException("Not supported on sync operation");
+      }
+
+      @Override
+      public void cancel(CancelContext ctx) {
+        throw new UnsupportedOperationException("Not supported on sync operation");
+      }
+    };
+  }
+
+  /**
+   * Handle the start of an operation.
+   *
+   * <p>The operation can be synchronous or asynchronous. Synchronous operations can return the
+   * result via {@link StartResult#sync}. Asynchronous operations can return the started operation
+   * ID via {@link StartResult#async}.
+   *
+   * @param ctx Context containing details about the call.
+   * @param param Parameter for the operation. This may be null if the parameter was not given.
+   * @return The start result which is a synchronous value or an operation ID representing an
+   *     asynchronously running operation.
+   * @throws OperationUnsuccessfulException If thrown, can have failure details and state such as
+   *     saying the operation was cancelled.
+   * @throws RuntimeException Any other exception fails the operation start as an operation failure.
+   */
+  StartResult<R> start(StartContext ctx, @Nullable T param) throws OperationUnsuccessfulException;
+
+  /**
+   * Fetch the result for an asynchronously started operation.
+   *
+   * @param ctx Context containing details about the call including the operation ID. The context
+   *     also contains a timeout which affects how implementers should implement this function. See
+   *     {@link FetchResultContext#getTimeout()} to see how to react to this value.
+   * @return The resulting value upon success.
+   * @throws OperationNotFoundException Operation ID provided is not a known ID.
+   * @throws OperationStillRunningException Operation is still running beyond the given timeout.
+   * @throws OperationUnsuccessfulException Operation failed. If thrown, can have failure details
+   *     and state such as saying the operation was cancelled.
+   * @throws RuntimeException Any other exception is considered a failure to fetch the result.
+   */
+  R fetchResult(FetchResultContext ctx)
+      throws OperationNotFoundException,
+          OperationStillRunningException,
+          OperationUnsuccessfulException;
+
+  /**
+   * Fetch information about the asynchronously started operation.
+   *
+   * @param ctx Context containing details about the call including the operation ID.
+   * @return Information about the operation.
+   * @throws OperationNotFoundException Operation ID provided is not a known ID.
+   * @throws RuntimeException Any other exception is considered a failure to fetch the info.
+   */
+  OperationInfo fetchInfo(FetchInfoContext ctx) throws OperationNotFoundException;
+
+  /**
+   * Cancel the asynchronously started operation.
+   *
+   * <p>This does not need to wait for cancellation to be processed, simply that cancellation is
+   * delivered. Duplicate cancellation requests for an operation or cancellation requests for an
+   * operation not running should just be ignored.
+   *
+   * @param ctx Context containing details about the call including the operation ID.
+   * @throws OperationNotFoundException Operation ID provided is not a known ID.
+   */
+  void cancel(CancelContext ctx) throws OperationNotFoundException;
+
+  /**
+   * Result for {@link #start}.
+   *
+   * <p>This is either a synchronous result (created via {@link #sync}) or asynchronous operation ID
+   * (created via {@link #async}).
+   */
+  class StartResult<R> {
+    /** Create a completed synchronous operation start result from the given value. */
+    public static <R> StartResult<R> sync(R value) {
+      return new StartResult<>(value, null);
+    }
+
+    /** Create a started asynchronous operation start result with the given operation ID. */
+    public static <R> StartResult<R> async(String operationId) {
+      return new StartResult<>(null, operationId);
+    }
+
+    private final @Nullable R syncResult;
+    private final @Nullable String asyncOperationId;
+
+    private StartResult(@Nullable R syncResult, @Nullable String asyncOperationId) {
+      this.syncResult = syncResult;
+      this.asyncOperationId = asyncOperationId;
+    }
+
+    /** Whether this start result is synchronous or asynchronous. */
+    public boolean isSync() {
+      return asyncOperationId == null;
+    }
+
+    /**
+     * The synchronous result. This can be null if the result is actually null or it is an
+     * asynchronous operation.
+     */
+    public @Nullable R getSyncResult() {
+      return syncResult;
+    }
+
+    /** The asynchronous operation ID. This will be null if the operation result is synchronous. */
+    public @Nullable String getAsyncOperationId() {
+      return asyncOperationId;
+    }
+  }
+
+  /** Context for {@link #start}. */
+  interface StartContext {
+    /** Service name. */
+    String getService();
+
+    /** Operation name. */
+    String getOperation();
+
+    /** Headers. Key accessing on this map is case-insensitive. */
+    Map<String, String> getHeaders();
+
+    /**
+     * Optional callback for asynchronous operations to deliver results to. If this is present and
+     * the implementation is an asynchronous operation, the implementation should ensure this
+     * callback is invoked with the result upon completion.
+     */
+    @Nullable String getCallbackUrl();
+
+    /** Headers to use on the callback if {@link #getCallbackUrl} is used. */
+    Map<String, String> getCallbackHeaders();
+
+    /** Unique request identifier from the caller to be used for deduplication. */
+    String getRequestId();
+  }
+
+  /** Context for {@link #fetchResult}. */
+  interface FetchResultContext {
+    /** Service name. */
+    String getService();
+
+    /** Operation name. */
+    String getOperation();
+
+    /** Operation ID. */
+    String getOperationId();
+
+    /**
+     * Optional timeout for how long the user want to wait on the result.
+     *
+     * <p>If this value is null, the result or {@link OperationStillRunningException} should be
+     * returned/thrown right away. If this value is present, the fetch result call should try to
+     * wait up until this duration or until an implementer chosen maximum, whichever ends sooner,
+     * before returning the result or throwing {@link OperationStillRunningException}.
+     */
+    @Nullable Duration getTimeout();
+
+    /** Headers. Key accessing on this map is case-insensitive. */
+    Map<String, String> getHeaders();
+  }
+
+  /** Context for {@link #fetchInfo}. */
+  interface FetchInfoContext {
+    /** Service name. */
+    String getService();
+
+    /** Operation name. */
+    String getOperation();
+
+    /** Operation ID. */
+    String getOperationId();
+
+    /** Headers. Key accessing on this map is case-insensitive. */
+    Map<String, String> getHeaders();
+  }
+
+  /** Context for {@link #cancel}. */
+  interface CancelContext {
+    /** Service name. */
+    String getService();
+
+    /** Operation name. */
+    String getOperation();
+
+    /** Operation ID. */
+    String getOperationId();
+
+    /** Headers. Key accessing on this map is case-insensitive. */
+    Map<String, String> getHeaders();
+  }
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationImpl.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationImpl.java
@@ -1,0 +1,22 @@
+package io.nexusrpc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method on a {@link ServiceImpl} as an implementation of an {@link Operation}.
+ *
+ * <p>The method with this annotation must be non-static, public, and have the same name as the
+ * {@link Operation} annotated method in the service being represented. The method must accept no
+ * arguments and return a {@link OperationHandler} with the first type variable as the operation
+ * parameter type (or {@link Void} if none) and the second type variable as the operation return
+ * type (or {@link Void} if void).
+ *
+ * <p>The method should not throw any exceptions and will only be called once to get the handler.
+ * That handler will be reused for each operation.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface OperationImpl {}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationInfo.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationInfo.java
@@ -1,0 +1,77 @@
+package io.nexusrpc;
+
+import java.util.Objects;
+import org.jspecify.annotations.Nullable;
+
+/** Information about an operation. */
+public class OperationInfo {
+  private final String id;
+  private final OperationState state;
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static Builder newBuilder(OperationInfo info) {
+    return new Builder(info);
+  }
+
+  private OperationInfo(String id, OperationState state) {
+    this.id = id;
+    this.state = state;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public OperationState getState() {
+    return state;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    OperationInfo that = (OperationInfo) o;
+    return Objects.equals(id, that.id) && state == that.state;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, state);
+  }
+
+  @Override
+  public String toString() {
+    return "OperationInfo{" + "id='" + id + '\'' + ", state=" + state + '}';
+  }
+
+  public static class Builder {
+    @Nullable private String id;
+    @Nullable private OperationState state;
+
+    private Builder() {}
+
+    private Builder(OperationInfo info) {
+      id = info.id;
+      state = info.state;
+    }
+
+    public Builder setId(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder setState(OperationState state) {
+      this.state = state;
+      return this;
+    }
+
+    public OperationInfo build() {
+      Objects.requireNonNull(id, "ID required");
+      Objects.requireNonNull(state, "State required");
+      return new OperationInfo(id, state);
+    }
+  }
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationNotFoundException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationNotFoundException.java
@@ -1,0 +1,8 @@
+package io.nexusrpc;
+
+/** An operation was not found for an ID. */
+public class OperationNotFoundException extends Exception {
+  public OperationNotFoundException() {
+    super("Operation not found");
+  }
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationState.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationState.java
@@ -1,0 +1,8 @@
+package io.nexusrpc;
+
+public enum OperationState {
+  RUNNING,
+  SUCCEEDED,
+  FAILED,
+  CANCELLED,
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationState.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationState.java
@@ -1,8 +1,13 @@
 package io.nexusrpc;
 
+/** State an operation can be in. */
 public enum OperationState {
+  /** Indicates an operation is started and not yet completed. */
   RUNNING,
+  /** Indicates an operation completed successfully. */
   SUCCEEDED,
+  /** Indicates an operation completed as failed. */
   FAILED,
+  /** Indicates an operation completed as canceled. */
   CANCELLED,
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationStillRunningException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationStillRunningException.java
@@ -1,0 +1,8 @@
+package io.nexusrpc;
+
+/** An operation result was requested, but it is still running. */
+public class OperationStillRunningException extends Exception {
+  public OperationStillRunningException() {
+    super("Operation still running");
+  }
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationUnsuccessfulException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationUnsuccessfulException.java
@@ -1,0 +1,29 @@
+package io.nexusrpc;
+
+/** An operation has failed or was cancelled. */
+public class OperationUnsuccessfulException extends Exception {
+  private final OperationState state;
+  private final OperationFailure failure;
+
+  public OperationUnsuccessfulException(String message) {
+    this(OperationState.FAILED, message);
+  }
+
+  public OperationUnsuccessfulException(OperationState state, String message) {
+    this(state, OperationFailure.newBuilder().setMessage(message).build());
+  }
+
+  public OperationUnsuccessfulException(OperationState state, OperationFailure failure) {
+    super(failure.getMessage());
+    this.state = state;
+    this.failure = failure;
+  }
+
+  public OperationState getState() {
+    return state;
+  }
+
+  public OperationFailure getFailure() {
+    return failure;
+  }
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/OperationUnsuccessfulException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/OperationUnsuccessfulException.java
@@ -3,27 +3,27 @@ package io.nexusrpc;
 /** An operation has failed or was cancelled. */
 public class OperationUnsuccessfulException extends Exception {
   private final OperationState state;
-  private final OperationFailure failure;
+  private final FailureInfo failureInfo;
 
   public OperationUnsuccessfulException(String message) {
     this(OperationState.FAILED, message);
   }
 
   public OperationUnsuccessfulException(OperationState state, String message) {
-    this(state, OperationFailure.newBuilder().setMessage(message).build());
+    this(state, FailureInfo.newBuilder().setMessage(message).build());
   }
 
-  public OperationUnsuccessfulException(OperationState state, OperationFailure failure) {
-    super(failure.getMessage());
+  public OperationUnsuccessfulException(OperationState state, FailureInfo failureInfo) {
+    super(failureInfo.getMessage());
     this.state = state;
-    this.failure = failure;
+    this.failureInfo = failureInfo;
   }
 
   public OperationState getState() {
     return state;
   }
 
-  public OperationFailure getFailure() {
-    return failure;
+  public FailureInfo getFailureInfo() {
+    return failureInfo;
   }
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/Service.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/Service.java
@@ -6,10 +6,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Services are interfaces that contain {@link Operation} methods. For proxying reasons, this can
- * only be declared on an interface. This annotation is not inherited, so it must be on any
- * sub-interface with the same values or an error will occur. Similarly, an error will occur if an
+ * Services are interfaces that contain {@link Operation} methods.
+ *
+ * <p>This can only be declared on an interface. This annotation is not inherited, so it must be on
+ * any sub-interface with the same name or an error will occur. Similarly, an error will occur if an
  * implementation implements multiple interfaces with this annotation with any different values.
+ *
+ * <p>All methods within (even on super interfaces) must be annotated with {@link Operation} and
+ * must conform to the rules of that annotation. Two operations with the same name are not allowed.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/nexus-sdk/src/main/java/io/nexusrpc/ServiceDefinition.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/ServiceDefinition.java
@@ -1,16 +1,130 @@
 package io.nexusrpc;
 
+import java.lang.reflect.Method;
 import java.util.*;
+import org.jspecify.annotations.Nullable;
 
+/** Definition of a service with operations. */
 public class ServiceDefinition {
+  /**
+   * Create a service definition from a {@link Service} annotated interface. This will fail if the
+   * service interface is invalid according to rules documented on the annotation.
+   */
   public static ServiceDefinition fromClass(Class<?> clazz) {
-    throw new UnsupportedOperationException("TODO");
+    Service service = clazz.getDeclaredAnnotation(Service.class);
+    if (service == null) {
+      throw new IllegalArgumentException("Missing @Service annotation");
+    } else if (!clazz.isInterface()) {
+      throw new IllegalArgumentException("Must be an interface");
+    }
+    String name = service.name().isEmpty() ? clazz.getSimpleName() : service.name();
+    Builder builder = newBuilder().setName(name);
+
+    // Collect all interfaces and declared methods (use linked hash set to keep in deterministic
+    // order). Set of methods for each item are ones that can override each other.
+    Set<Class<?>> interfaces = new LinkedHashSet<>();
+    List<List<Method>> methods = new ArrayList<>();
+    collectInterfaceInfo(clazz, interfaces, methods);
+
+    // Check that if any interfaces have a service annotation, it matches this one
+    for (Class<?> iface : interfaces) {
+      Service subService = iface.getDeclaredAnnotation(Service.class);
+      if (subService != null) {
+        String subName = subService.name().isEmpty() ? iface.getSimpleName() : subService.name();
+        if (!name.equals(subName)) {
+          throw new IllegalArgumentException(
+              "Interface "
+                  + iface.getName()
+                  + " has a service annotation whose name ("
+                  + subName
+                  + ") does not match the expected name on the final interface ("
+                  + name
+                  + ")");
+        }
+      }
+    }
+
+    // Build operations, collecting failures
+    List<String> operationFailures = new ArrayList<>();
+    for (List<Method> methodSet : methods) {
+      // Every method must be an operation, so we make definitions for all, and
+      // in any case where the definition doesn't match, it's an error.
+      OperationDefinition firstOperation = null;
+      for (Method method : methodSet) {
+        try {
+          OperationDefinition thisOperation = OperationDefinition.fromMethod(method);
+          if (firstOperation == null) {
+            firstOperation = thisOperation;
+            builder.addOperation(firstOperation);
+          } else if (!firstOperation.equals(thisOperation)) {
+            operationFailures.add(
+                "Operation definition on "
+                    + method.getName()
+                    + " on "
+                    + method.getDeclaringClass().getName()
+                    + " mismatches against another operation of the same name/signature in the hierarchy");
+            break;
+          }
+        } catch (Exception e) {
+          operationFailures.add(
+              "Operation definition on "
+                  + method.getName()
+                  + " on "
+                  + method.getDeclaringClass().getName()
+                  + " is invalid: "
+                  + e.getMessage());
+          break;
+        }
+      }
+    }
+
+    // Fail if there are any operation failures
+    if (!operationFailures.isEmpty()) {
+      throw new IllegalArgumentException(
+          operationFailures.size()
+              + " operation(s) were invalid, reasons: "
+              + String.join(", ", operationFailures));
+    }
+    // Let the service builder fail for the rest
+    return builder.build();
   }
 
+  // Every method in the list is a matching override
+  private static void collectInterfaceInfo(
+      Class<?> iface, Set<Class<?>> interfaces, List<List<Method>> methods) {
+    interfaces.add(iface);
+    for (Method method : iface.getDeclaredMethods()) {
+      // Try to find existing method that matches the name and parameter types
+      // as a poor-man's virtual/override check (we don't allow generics anyway).
+      // Otherwise, add as a new list.
+      methods.stream()
+          .filter(
+              possible ->
+                  possible.get(0).getName().equals(method.getName())
+                      && Arrays.equals(
+                          possible.get(0).getParameterTypes(), method.getParameterTypes()))
+          .findFirst()
+          .orElseGet(
+              () -> {
+                List<Method> newList = new ArrayList<>();
+                methods.add(newList);
+                return newList;
+              })
+          .add(method);
+    }
+    for (Class<?> parent : iface.getInterfaces()) {
+      if (!interfaces.contains(parent)) {
+        collectInterfaceInfo(parent, interfaces, methods);
+      }
+    }
+  }
+
+  /** Create a builder for a service definition. */
   public static Builder newBuilder() {
     return new Builder();
   }
 
+  /** Create a builder for a service definition from an existing service definition. */
   public static Builder newBuilder(ServiceDefinition definition) {
     return new Builder(definition);
   }
@@ -23,10 +137,12 @@ public class ServiceDefinition {
     this.operations = operations;
   }
 
+  /** Service name. */
   public String getName() {
     return name;
   }
 
+  /** Collection of operations. */
   public List<OperationDefinition> getOperations() {
     return operations;
   }
@@ -49,29 +165,51 @@ public class ServiceDefinition {
     return "ServiceDefinition{" + "name='" + name + '\'' + ", operations=" + operations + '}';
   }
 
+  /** Builder for a service definition. */
   public static class Builder {
-    private String name;
-    private final List<OperationDefinition> operations = new ArrayList<>();
+    @Nullable private String name;
+    private final List<OperationDefinition> operations;
 
-    private Builder() {}
+    private Builder() {
+      operations = new ArrayList<>();
+    }
 
     private Builder(ServiceDefinition definition) {
-      if (definition == null) {
-        return;
-      }
-      this.name = definition.name;
-      this.operations.addAll(definition.operations);
+      name = definition.name;
+      operations = new ArrayList<>(definition.operations);
     }
 
-    public void setName(String name) {
+    /** Set service name, required. */
+    public Builder setName(String name) {
       this.name = name;
+      return this;
     }
 
+    /** Get operations, at least one required. */
     public List<OperationDefinition> getOperations() {
       return operations;
     }
 
+    /** Add operations, at least one required. */
+    public Builder addOperation(OperationDefinition definition) {
+      operations.add(definition);
+      return this;
+    }
+
+    /** Build the service definition. */
     public ServiceDefinition build() {
+      Objects.requireNonNull(name, "Name required");
+      if (operations.isEmpty()) {
+        throw new IllegalStateException("No operations defined");
+      }
+      Set<String> seenNames = new HashSet<>();
+      for (OperationDefinition operation : operations) {
+        if (seenNames.contains(operation.getName())) {
+          throw new IllegalStateException(
+              "Multiple operations named '" + operation.getName() + "'");
+        }
+        seenNames.add(operation.getName());
+      }
       return new ServiceDefinition(name, Collections.unmodifiableList(new ArrayList<>(operations)));
     }
   }

--- a/nexus-sdk/src/main/java/io/nexusrpc/ServiceImpl.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/ServiceImpl.java
@@ -1,0 +1,20 @@
+package io.nexusrpc;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a class as an implementation of a {@link Service} interface.
+ *
+ * <p>For every method in {@link #service}, this class must have an equivalent non-static, public
+ * method annotated with {@link OperationImpl}. See that annotation's documentation for more
+ * details.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ServiceImpl {
+  /** The {@link Service}-annotated interface. */
+  Class<?> service();
+}

--- a/nexus-sdk/src/main/java/io/nexusrpc/package-info.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.nexusrpc;
+
+import org.jspecify.annotations.NullMarked;

--- a/nexus-sdk/src/test/java/io/nexusrpc/ServiceDefinitionTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/ServiceDefinitionTest.java
@@ -1,10 +1,177 @@
 package io.nexusrpc;
 
-import org.junit.jupiter.api.Disabled;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.lang.reflect.Type;
 import org.junit.jupiter.api.Test;
 
 public class ServiceDefinitionTest {
+
+  interface InvalidServiceNoAnnotation {}
+
+  @Service
+  static class InvalidServiceAsClass {}
+
+  @Service
+  interface InvalidSuperService {}
+
+  @Service
+  interface InvalidSubService extends InvalidSuperService {}
+
+  @Service(name = "invalid-service-with-operations")
+  interface InvalidSuperServiceWithOperations {
+    void superMethodWithNoAnnotation();
+
+    @Operation(name = "super-method-different-name1")
+    void superMethodDifferentName();
+
+    @Operation
+    Object covariantReturn();
+  }
+
+  @Service(name = "invalid-service-with-operations")
+  interface InvalidServiceWithOperations extends InvalidSuperServiceWithOperations {
+    void methodWithNoAnnotation();
+
+    @Operation
+    void superMethodWithNoAnnotation();
+
+    @Operation
+    void twoParameterOperation(String one, String two);
+
+    @Operation
+    <T> void genericOperation(T param);
+
+    @Operation
+    void hasThrowsClause() throws Exception;
+
+    @Operation
+    default void hasDefault() {}
+
+    @Operation
+    static void staticOperation() {}
+
+    @Operation(name = "super-method-different-name2")
+    void superMethodDifferentName();
+
+    @Operation
+    String covariantReturn();
+  }
+
+  @Service
+  interface InvalidServiceDuplicateOperation {
+    @Operation
+    void duplicateWhenNameOverridden1();
+
+    @Operation(name = "duplicateWhenNameOverridden1")
+    void duplicateWhenNameOverridden2();
+  }
+
+  private static void assertInvalidService(Class<?> clazz, String... expectedFailures) {
+    try {
+      ServiceDefinition.fromClass(clazz);
+      fail("Expected failures, none found");
+    } catch (Exception e) {
+      for (String expectedFailure : expectedFailures) {
+        assertTrue(
+            e.getMessage().contains(expectedFailure),
+            "Expected '"
+                + expectedFailure
+                + "' to appear in the exception message of: "
+                + e.getMessage());
+      }
+    }
+  }
+
+  private static String expectedOperationFailure(String method, String message) {
+    return expectedOperationFailure(method, InvalidServiceWithOperations.class, message);
+  }
+
+  private static String expectedOperationFailure(String method, Class<?> clazz, String message) {
+    return method + " on " + clazz.getName() + " is invalid: " + message;
+  }
+
   @Test
-  @Disabled("TODO")
-  void simpleTest() {}
+  void invalidService() {
+    assertInvalidService(InvalidServiceNoAnnotation.class, "Missing @Service annotation");
+    assertInvalidService(InvalidServiceAsClass.class, "Must be an interface");
+    assertInvalidService(
+        InvalidSubService.class,
+        "InvalidSuperService has a service annotation whose name (InvalidSuperService) "
+            + "does not match the expected name on the final interface (InvalidSubService)");
+    assertInvalidService(
+        InvalidServiceWithOperations.class,
+        expectedOperationFailure("methodWithNoAnnotation", "Missing @Operation annotation"),
+        expectedOperationFailure(
+            "superMethodWithNoAnnotation",
+            InvalidSuperServiceWithOperations.class,
+            "Missing @Operation annotation"),
+        expectedOperationFailure("twoParameterOperation", "Can have no more than one parameter"),
+        expectedOperationFailure("genericOperation", "Cannot be generic"),
+        expectedOperationFailure("hasThrowsClause", "Cannot have throws clause"),
+        expectedOperationFailure("hasDefault", "Cannot have default implementation"),
+        expectedOperationFailure("staticOperation", "Cannot be static"),
+        "superMethodDifferentName on "
+            + InvalidSuperServiceWithOperations.class.getName()
+            + " mismatches against another operation of the same name/signature",
+        "covariantReturn on "
+            + InvalidServiceWithOperations.class.getName()
+            + " mismatches against another operation of the same name/signature");
+    assertInvalidService(
+        InvalidServiceDuplicateOperation.class,
+        "Multiple operations named 'duplicateWhenNameOverridden1'");
+  }
+
+  @Service(name = "ValidServiceWithOperations")
+  interface ValidSuperServiceWithOperations {
+    @Operation
+    void superMethod();
+
+    @Operation
+    void superInterfaceOnly();
+  }
+
+  @Service
+  interface ValidServiceWithOperations extends ValidSuperServiceWithOperations {
+    @Operation
+    void superMethod();
+
+    @Operation
+    void noParamNoReturn();
+
+    @Operation
+    String noParamSingleReturn();
+
+    @Operation
+    void singleParamNoReturn(String param);
+
+    @Operation
+    String singleParamSingleReturn(String param);
+
+    @Operation(name = "custom-name")
+    void customName();
+  }
+
+  private static void assertOperationExists(
+      ServiceDefinition defn, String name, Type outputType, Type inputType) {
+    assertTrue(
+        defn.getOperations()
+            .contains(
+                OperationDefinition.newBuilder()
+                    .setName(name)
+                    .setOutputType(outputType)
+                    .setInputType(inputType)
+                    .build()));
+  }
+
+  @Test
+  void validService() {
+    ServiceDefinition defn = ServiceDefinition.fromClass(ValidServiceWithOperations.class);
+    assertOperationExists(defn, "superMethod", Void.TYPE, Void.TYPE);
+    assertOperationExists(defn, "noParamNoReturn", Void.TYPE, Void.TYPE);
+    assertOperationExists(defn, "noParamSingleReturn", String.class, Void.TYPE);
+    assertOperationExists(defn, "singleParamNoReturn", Void.TYPE, String.class);
+    assertOperationExists(defn, "singleParamSingleReturn", String.class, String.class);
+    assertOperationExists(defn, "custom-name", Void.TYPE, Void.TYPE);
+  }
 }

--- a/nexus-sdk/src/test/java/io/nexusrpc/example/ApiClient.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/example/ApiClient.java
@@ -1,0 +1,7 @@
+package io.nexusrpc.example;
+
+import java.util.concurrent.Future;
+
+public interface ApiClient {
+  Future<String> createGreeting(String name);
+}

--- a/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingService.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingService.java
@@ -1,0 +1,13 @@
+package io.nexusrpc.example;
+
+import io.nexusrpc.Operation;
+import io.nexusrpc.Service;
+
+@Service
+public interface GreetingService {
+  @Operation
+  String sayHello1(String name);
+
+  @Operation
+  String sayHello2(String name);
+}

--- a/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingServiceImpl.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingServiceImpl.java
@@ -1,0 +1,110 @@
+package io.nexusrpc.example;
+
+import io.nexusrpc.*;
+import java.util.UUID;
+import java.util.concurrent.*;
+import org.jspecify.annotations.Nullable;
+
+@ServiceImpl(service = GreetingService.class)
+public class GreetingServiceImpl {
+  private final ApiClient apiClient;
+
+  public GreetingServiceImpl(ApiClient apiClient) {
+    this.apiClient = apiClient;
+  }
+
+  @OperationImpl
+  public OperationHandler<String, String> sayHello1() {
+    // Implemented inline
+    return OperationHandler.sync((ctx, name) -> "Hello, " + name + "!");
+  }
+
+  @OperationImpl
+  public OperationHandler<String, String> sayHello2() {
+    // Implemented via handler
+    return new SayHello2Handler();
+  }
+
+  // Naive example showing async operations tracked in-memory
+  private class SayHello2Handler implements OperationHandler<String, String> {
+    private final ConcurrentMap<String, Future<String>> operations = new ConcurrentHashMap<>();
+
+    @Override
+    public StartResult<String> start(StartContext ctx, @Nullable String name) {
+      // For purposes of this sample, let's say if name starts with sync we do a
+      // sync return. This demonstrates that at runtime the decision can be made.
+      if (name == null) {
+        name = "<unknown>";
+      }
+      if (name.startsWith("sync-")) {
+        return StartResult.sync("Hello, " + name + "!");
+      }
+      if (ctx.getCallbackUrl() != null) {
+        throw new IllegalArgumentException("This service does not support callbacks");
+      }
+      String id = UUID.randomUUID().toString();
+      operations.put(id, apiClient.createGreeting(name));
+      return StartResult.async(id);
+    }
+
+    @Override
+    public String fetchResult(FetchResultContext ctx)
+        throws OperationNotFoundException, OperationStillRunningException {
+      Future<String> operation = getOperation(ctx.getOperationId());
+      try {
+        // When timeout missing, be done or fail
+        if (ctx.getTimeout() == null) {
+          if (!operation.isDone()) {
+            throw new OperationStillRunningException();
+          }
+          return operation.get();
+        }
+        // User willing to wait
+        try {
+          return operation.get(ctx.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+          throw new OperationStillRunningException();
+        }
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      } catch (ExecutionException e) {
+        if (e.getCause() instanceof RuntimeException) {
+          throw (RuntimeException) e.getCause();
+        }
+        throw new RuntimeException(e.getCause());
+      }
+    }
+
+    @Override
+    public OperationInfo fetchInfo(FetchInfoContext ctx) throws OperationNotFoundException {
+      Future<String> operation = getOperation(ctx.getOperationId());
+      OperationState state;
+      if (operation.isCancelled()) {
+        state = OperationState.CANCELLED;
+      } else if (!operation.isDone()) {
+        state = OperationState.RUNNING;
+      } else {
+        try {
+          operation.get();
+          state = OperationState.SUCCEEDED;
+        } catch (Exception e) {
+          state = OperationState.FAILED;
+        }
+      }
+      return OperationInfo.newBuilder().setId(ctx.getOperationId()).setState(state).build();
+    }
+
+    @Override
+    public void cancel(CancelContext ctx) throws OperationNotFoundException {
+      getOperation(ctx.getOperationId()).cancel(true);
+    }
+
+    private Future<String> getOperation(String id) throws OperationNotFoundException {
+      Future<String> operation = operations.get(id);
+      if (operation == null) {
+        throw new OperationNotFoundException();
+      }
+      return operation;
+    }
+  }
+}

--- a/nexus-sdk/src/test/java/io/nexusrpc/example/package-info.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/example/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.nexusrpc.example;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
# What was changed

Initial operation abstraction was added with interfaces to define and implement operations. There are obvious missing pieces that are to come in successive PRs:

* The ability to match a `@ServiceImpl` with a `@Service` (and the `@Operation`/`@OperationImpl` pieces within)
* Nexus server and client