### PR TITLE
Rename DOWNSTREAM_TIMEOUT to UPSTREAM_TIMEOUT

### DIFF
--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationHandlerException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationHandlerException.java
@@ -67,7 +67,7 @@ public class OperationHandlerException extends RuntimeException {
      * the request.
      */
     UNAVAILABLE,
-    /** Used by gateways to report that a request to a downstream server has timed out. */
-    DOWNSTREAM_TIMEOUT
+    /** Used by gateways to report that a request to an upstream server has timed out. */
+    UPSTREAM_TIMEOUT
   }
 }


### PR DESCRIPTION
closes: https://github.com/nexus-rpc/sdk-java/issues/8