### PR TITLE
Switch URL to URI in link

### DIFF
--- a/nexus-sdk/src/main/java/io/nexusrpc/Link.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/Link.java
@@ -69,7 +69,7 @@ public class Link {
     }
 
     /** Set URI information about the link. It must be URL percent-encoded. */
-    public Link.Builder setURI(URI uri) {
+    public Link.Builder setUri(URI uri) {
       this.uri = uri;
       return this;
     }

--- a/nexus-sdk/src/main/java/io/nexusrpc/Link.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/Link.java
@@ -1,12 +1,12 @@
 package io.nexusrpc;
 
-import java.net.URL;
+import java.net.URI;
 import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Link contains a URL and a Type that can be used to decode the URL. Links can contain any
- * arbitrary information as a percent-encoded URL. It can be used to pass information about the
+ * Link contains a URI and a Type that can be used to decode the URI. Links can contain any
+ * arbitrary information as a percent-encoded URI. It can be used to pass information about the
  * caller to the handler, or vice-versa.
  */
 public class Link {
@@ -20,20 +20,20 @@ public class Link {
     return new Link.Builder(info);
   }
 
-  private final URL url;
+  private final URI uri;
   private final String type;
 
-  private Link(URL url, String type) {
-    this.url = url;
+  private Link(URI uri, String type) {
+    this.uri = uri;
     this.type = type;
   }
 
-  /** URL information about the link. */
-  public URL getUrl() {
-    return url;
+  /** URI information about the link. */
+  public URI getUri() {
+    return uri;
   }
 
-  /** Type can describe an actual data type for decoding the URL. */
+  /** Type can describe an actual data type for decoding the URI. */
   public String getType() {
     return type;
   }
@@ -43,39 +43,39 @@ public class Link {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     Link link = (Link) o;
-    return Objects.equals(url, link.url) && Objects.equals(type, link.type);
+    return Objects.equals(uri, link.uri) && Objects.equals(type, link.type);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(url, type);
+    return Objects.hash(uri, type);
   }
 
   @Override
   public String toString() {
-    return "Link{" + "url=" + url + ", type='" + type + '\'' + '}';
+    return "Link{" + "uri=" + uri + ", type='" + type + '\'' + '}';
   }
 
   /** Builder for link. */
   public static class Builder {
-    private @Nullable URL url;
+    private @Nullable URI uri;
     private @Nullable String type;
 
     private Builder() {}
 
     private Builder(Link link) {
-      url = link.url;
+      uri = link.uri;
       type = link.type;
     }
 
-    /** Set URL information about the link. It must be URL percent-encoded. */
-    public Link.Builder setUrl(URL url) {
-      this.url = url;
+    /** Set URI information about the link. It must be URL percent-encoded. */
+    public Link.Builder setURI(URI uri) {
+      this.uri = uri;
       return this;
     }
 
     /**
-     * Type can describe an actual data type for decoding the URL. Valid chars: alphanumeric, '_',
+     * Type can describe an actual data type for decoding the URI. Valid chars: alphanumeric, '_',
      * '.', '/'
      */
     public Link.Builder setType(String type) {
@@ -85,9 +85,9 @@ public class Link {
 
     /** Build the link. */
     public Link build() {
-      Objects.requireNonNull(url, "URL required");
+      Objects.requireNonNull(uri, "URI required");
       Objects.requireNonNull(type, "Type required");
-      return new Link(url, type);
+      return new Link(uri, type);
     }
   }
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationStartDetails.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationStartDetails.java
@@ -102,7 +102,7 @@ public class OperationStartDetails {
     }
 
     /** Add a link. */
-    public Builder addLinks(Link link) {
+    public Builder addLink(Link link) {
       this.links.add(link);
       return this;
     }

--- a/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingServiceImpl.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingServiceImpl.java
@@ -53,7 +53,7 @@ public class GreetingServiceImpl {
           URI url = new URI("http://somepath?k=v");
           return OperationStartResult.<String>newBuilder()
               .setAsyncOperationId(id)
-              .addLink(Link.newBuilder().setURI(url).setType("com.example.MyResource").build())
+              .addLink(Link.newBuilder().setUri(url).setType("com.example.MyResource").build())
               .build();
         } catch (URISyntaxException e) {
           throw new RuntimeException(e);

--- a/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingServiceImpl.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/example/GreetingServiceImpl.java
@@ -2,8 +2,8 @@ package io.nexusrpc.example;
 
 import io.nexusrpc.*;
 import io.nexusrpc.handler.*;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.UUID;
 import java.util.concurrent.*;
 import org.jspecify.annotations.Nullable;
@@ -50,12 +50,12 @@ public class GreetingServiceImpl {
       operations.put(id, apiClient.createGreeting(name));
       if (name.endsWith("link")) {
         try {
-          URL url = new URL("http://somepath?k=v");
+          URI url = new URI("http://somepath?k=v");
           return OperationStartResult.<String>newBuilder()
               .setAsyncOperationId(id)
-              .addLink(Link.newBuilder().setUrl(url).setType("com.example.MyResource").build())
+              .addLink(Link.newBuilder().setURI(url).setType("com.example.MyResource").build())
               .build();
-        } catch (MalformedURLException e) {
+        } catch (URISyntaxException e) {
           throw new RuntimeException(e);
         }
       }

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/ServiceHandlerTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/ServiceHandlerTest.java
@@ -98,7 +98,7 @@ public class ServiceHandlerTest {
     Objects.requireNonNull(resultWithLink.getAsyncOperationId());
     List<Link> links = Objects.requireNonNull(resultWithLink.getLinks());
     assertEquals(1, links.size());
-    assertEquals("http://somepath?k=v", links.get(0).getUrl().toString());
+    assertEquals("http://somepath?k=v", links.get(0).getUri().toString());
     assertEquals("com.example.MyResource", links.get(0).getType());
   }
 


### PR DESCRIPTION
Switch URL to URI in link since `URL` constructors are deprecated in Java 20 and using a URL with a custom protocol is painful.