### PR TITLE
Make headers case insensitive

### DIFF
--- a/nexus-sdk/src/main/java/io/nexusrpc/Serializer.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/Serializer.java
@@ -93,11 +93,14 @@ public interface Serializer {
         // TODO(cretz): Most of the time the headers come over immutable
         // anyways, are we unnecessarily introducing overhead copying them every
         // time?
-        Map<String, String> normalizedHeaders =
+        SortedMap<String, String> normalizedHeaders =
             headers.entrySet().stream()
                 .collect(
                     Collectors.toMap(
-                        entry -> entry.getKey().toLowerCase(), entry -> entry.getValue()));
+                        (k) -> k.getKey().toLowerCase(),
+                        Map.Entry::getValue,
+                        (a, b) -> a,
+                        () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
         return new Content(data, Collections.unmodifiableMap(new TreeMap<>(normalizedHeaders)));
       }
     }

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerInputContent.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerInputContent.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
 /** Content that can be fixed or streaming for start operation input. */
@@ -53,7 +54,7 @@ public class HandlerInputContent {
     return buffer.toByteArray();
   }
 
-  /** Headers. */
+  /** Headers. The returned map operates without regard to case. */
   public Map<String, String> getHeaders() {
     return headers;
   }
@@ -61,10 +62,10 @@ public class HandlerInputContent {
   /** Builder for content. */
   public static class Builder {
     private @Nullable InputStream dataStream;
-    private final Map<String, String> headers;
+    private final SortedMap<String, String> headers;
 
     private Builder() {
-      headers = new HashMap<>();
+      headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     }
 
     /** Set data stream. Required. */
@@ -89,8 +90,13 @@ public class HandlerInputContent {
       // TODO(cretz): Most of the time the headers come over immutable
       // anyways, are we unnecessarily introducing overhead copying them every
       // time?
+      Map<String, String> normalizedHeaders =
+          headers.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      entry -> entry.getKey().toLowerCase(), entry -> entry.getValue()));
       return new HandlerInputContent(
-          dataStream, Collections.unmodifiableMap(new HashMap<>(headers)));
+          dataStream, Collections.unmodifiableMap(new TreeMap<>(normalizedHeaders)));
     }
   }
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerInputContent.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerInputContent.java
@@ -90,11 +90,14 @@ public class HandlerInputContent {
       // TODO(cretz): Most of the time the headers come over immutable
       // anyways, are we unnecessarily introducing overhead copying them every
       // time?
-      Map<String, String> normalizedHeaders =
+      SortedMap<String, String> normalizedHeaders =
           headers.entrySet().stream()
               .collect(
                   Collectors.toMap(
-                      entry -> entry.getKey().toLowerCase(), entry -> entry.getValue()));
+                      (k) -> k.getKey().toLowerCase(),
+                      Map.Entry::getValue,
+                      (a, b) -> a,
+                      () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
       return new HandlerInputContent(
           dataStream, Collections.unmodifiableMap(new TreeMap<>(normalizedHeaders)));
     }

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerResultContent.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerResultContent.java
@@ -106,11 +106,14 @@ public class HandlerResultContent {
       // TODO(cretz): Most of the time the headers come over immutable
       // anyways, are we unnecessarily introducing overhead copying them every
       // time?
-      Map<String, String> normalizedHeaders =
+      SortedMap<String, String> normalizedHeaders =
           headers.entrySet().stream()
               .collect(
                   Collectors.toMap(
-                      entry -> entry.getKey().toLowerCase(), entry -> entry.getValue()));
+                      (k) -> k.getKey().toLowerCase(),
+                      Map.Entry::getValue,
+                      (a, b) -> a,
+                      () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
       return new HandlerResultContent(
           dataBytes, dataStream, Collections.unmodifiableMap(new TreeMap<>(normalizedHeaders)));
     }

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
@@ -164,11 +164,14 @@ public class OperationContext {
     public OperationContext build() {
       Objects.requireNonNull(service, "Service required");
       Objects.requireNonNull(operation, "Operation required");
-      Map<String, String> normalizedHeaders =
+      SortedMap<String, String> normalizedHeaders =
           headers.entrySet().stream()
               .collect(
                   Collectors.toMap(
-                      entry -> entry.getKey().toLowerCase(), entry -> entry.getValue()));
+                      (k) -> k.getKey().toLowerCase(),
+                      Map.Entry::getValue,
+                      (a, b) -> a,
+                      () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)));
       return new OperationContext(
           service,
           operation,

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
@@ -1,9 +1,7 @@
 package io.nexusrpc.handler;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
 /** Context for use in operation handling. */
@@ -45,7 +43,7 @@ public class OperationContext {
     return operation;
   }
 
-  /** Headers for the call. */
+  /** Headers for the call. The returned map operates without regard to case. */
   public Map<String, String> getHeaders() {
     return headers;
   }
@@ -120,17 +118,17 @@ public class OperationContext {
   public static class Builder {
     private @Nullable String service;
     private @Nullable String operation;
-    private final Map<String, String> headers;
+    private final SortedMap<String, String> headers;
     private @Nullable OperationMethodCanceller methodCanceller;
 
     private Builder() {
-      headers = new HashMap<>();
+      headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
     }
 
     private Builder(OperationContext context) {
       service = context.service;
       operation = context.operation;
-      headers = new HashMap<>(context.headers);
+      headers = new TreeMap<>(context.headers);
     }
 
     /** Set service. Required. */
@@ -145,7 +143,7 @@ public class OperationContext {
       return this;
     }
 
-    /** Get headers to mutate. */
+    /** Get headers to mutate. The returned map operates without regard to case. */
     public Map<String, String> getHeaders() {
       return headers;
     }
@@ -166,8 +164,16 @@ public class OperationContext {
     public OperationContext build() {
       Objects.requireNonNull(service, "Service required");
       Objects.requireNonNull(operation, "Operation required");
+      Map<String, String> normalizedHeaders =
+          headers.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      entry -> entry.getKey().toLowerCase(), entry -> entry.getValue()));
       return new OperationContext(
-          service, operation, Collections.unmodifiableMap(new HashMap<>(headers)), methodCanceller);
+          service,
+          operation,
+          Collections.unmodifiableMap(new TreeMap<>(normalizedHeaders)),
+          methodCanceller);
     }
   }
 }

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/HeaderTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/HeaderTest.java
@@ -1,0 +1,71 @@
+package io.nexusrpc.handler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.nexusrpc.Serializer;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class HeaderTest {
+  @Test
+  void operationContextHeaders() {
+    OperationContext context =
+        OperationContext.newBuilder()
+            .setOperation("operation")
+            .setService("service")
+            .putHeader("UPPER-CASE-HEADER", "UPPER-VALUE")
+            .putHeader("lower-case-header", "lower-value")
+            .build();
+    // Verify that the map is case-insensitive
+    verifyHeaders(context.getHeaders());
+  }
+
+  @Test
+  void handlerResultContentHeaders() {
+    HandlerResultContent result =
+        HandlerResultContent.newBuilder()
+            .setData(new byte[] {})
+            .putHeader("UPPER-CASE-HEADER", "UPPER-VALUE")
+            .putHeader("lower-case-header", "lower-value")
+            .build();
+    // Verify that the map is case-insensitive
+    verifyHeaders(result.getHeaders());
+  }
+
+  @Test
+  void contentHeaders() {
+    Serializer.Content content =
+        Serializer.Content.newBuilder()
+            .setData(new byte[] {})
+            .putHeader("UPPER-CASE-HEADER", "UPPER-VALUE")
+            .putHeader("lower-case-header", "lower-value")
+            .build();
+    // Verify that the map is case-insensitive
+    verifyHeaders(content.getHeaders());
+  }
+
+  @Test
+  void handlerInputHeaders() {
+    HandlerInputContent content =
+        HandlerInputContent.newBuilder()
+            .setDataStream(new ByteArrayInputStream("test".getBytes(StandardCharsets.UTF_8)))
+            .putHeader("UPPER-CASE-HEADER", "UPPER-VALUE")
+            .putHeader("lower-case-header", "lower-value")
+            .build();
+    // Verify that the map is case-insensitive
+    verifyHeaders(content.getHeaders());
+  }
+
+  void verifyHeaders(Map<String, String> headers) {
+    assertEquals("UPPER-VALUE", headers.get("upper-case-header"));
+    assertEquals("UPPER-VALUE", headers.get("UPPER-CASE-HEADER"));
+    assertEquals("lower-value", headers.get("lower-case-header"));
+    assertEquals("lower-value", headers.get("LOWER-CASE-HEADER"));
+    // Verify that all the keys are lower-case
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      assertEquals(entry.getKey().toLowerCase(), entry.getKey());
+    }
+  }
+}


### PR DESCRIPTION
Headers should be case insensitive in Nexus. Taking the same approach as the Java standard library by using a `TreeMap<>(String.CASE_INSENSITIVE_ORDER)`