### PR TITLE
Add Retryable header

### DIFF
--- a/nexus-sdk/src/main/java/io/nexusrpc/Header.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/Header.java
@@ -34,5 +34,12 @@ public class Header {
    */
   public static final String OPERATION_START_TIME = "Nexus-Operation-Start-Time";
 
+  /**
+   * Handlers may specify the Nexus-Request-Retryable header to explicitly instruct a caller whether
+   * to retry a request. Unless specified, retry behavior is determined from the predefined handler
+   * error type. For example INTERNAL errors is not retryable by default unless specified otherwise.
+   */
+  public static final String RETRYABLE = "Nexus-Request-Retryable";
+
   private Header() {}
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerException.java
@@ -100,8 +100,8 @@ public class HandlerException extends RuntimeException {
      */
     UNAUTHORIZED,
     /**
-     * The requested resource could not be found but may be available in the future. Subsequent
-     * requests by the client are permissible but not advised.
+     * The requested resource could not be found but may be available in the future. Clients should not retry this
+     * request unless advised otherwise.
      */
     NOT_FOUND,
     /**

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerException.java
@@ -4,15 +4,51 @@ import org.jspecify.annotations.Nullable;
 
 /** Thrown from a handler for any unexpected error. */
 public class HandlerException extends RuntimeException {
+
+  /**
+   * RetryBehavior allows handlers to explicitly set the retry behavior of a {@link
+   * HandlerException}. If not specified, retry behavior is determined from the error type. For
+   * example {@link HandlerException.ErrorType#INTERNAL} is not retryable by default unless
+   * specified otherwise.
+   */
+  public enum RetryBehavior {
+    /**
+     * Indicates the retry behavior for a {@link HandlerException} is determined by the {@link
+     * HandlerException.ErrorType}.
+     */
+    UNSPECIFIED,
+    /**
+     * Indicates that a {@link HandlerException} should be retried, overriding the default retry
+     * behavior of the {@link HandlerException.ErrorType}.
+     */
+    RETRYABLE,
+    /**
+     * Indicates that a {@link HandlerException} should not be retried, overriding the default retry
+     * behavior of the {@link HandlerException.ErrorType}.
+     */
+    NON_RETRYABLE
+  }
+
   private final ErrorType errorType;
+  private final RetryBehavior retryBehavior;
 
   public HandlerException(ErrorType errorType, String message) {
-    this(errorType, new RuntimeException(message));
+    this(errorType, new RuntimeException(message), RetryBehavior.UNSPECIFIED);
+  }
+
+  public HandlerException(ErrorType errorType, String message, RetryBehavior retryBehavior) {
+    this(errorType, new RuntimeException(message), retryBehavior);
   }
 
   public HandlerException(ErrorType errorType, @Nullable Throwable cause) {
+    this(errorType, cause, RetryBehavior.UNSPECIFIED);
+  }
+
+  public HandlerException(
+      ErrorType errorType, @Nullable Throwable cause, RetryBehavior retryBehavior) {
     super(cause == null ? "handler error" : "handler error: " + cause.getMessage(), cause);
     this.errorType = errorType;
+    this.retryBehavior = retryBehavior;
   }
 
   /** Error type for this exception. */
@@ -20,37 +56,72 @@ public class HandlerException extends RuntimeException {
     return errorType;
   }
 
+  /** Retry behavior for this exception. */
+  public RetryBehavior getRetryBehavior() {
+    return retryBehavior;
+  }
+
+  public boolean isRetryable() {
+    if (retryBehavior != RetryBehavior.UNSPECIFIED) {
+      return retryBehavior == RetryBehavior.RETRYABLE;
+    }
+    switch (errorType) {
+      case BAD_REQUEST:
+      case UNAUTHENTICATED:
+      case UNAUTHORIZED:
+      case NOT_FOUND:
+      case NOT_IMPLEMENTED:
+        return false;
+      case RESOURCE_EXHAUSTED:
+      case INTERNAL:
+      case UNAVAILABLE:
+      case UPSTREAM_TIMEOUT:
+        return true;
+      default:
+        throw new IllegalStateException("Unknown error type: " + errorType);
+    }
+  }
+
   /** Error type that can occur on a handler exception. */
   public enum ErrorType {
-    /** The server cannot or will not process the request due to an apparent client error. */
+    /**
+     * The server cannot or will not process the request due to an apparent client error. Clients
+     * should not retry this request unless advised otherwise.
+     */
     BAD_REQUEST,
-    /** The client did not supply valid authentication credentials for this request. */
+    /**
+     * The client did not supply valid authentication credentials for this request. Clients should
+     * not retry this request unless advised otherwise.
+     */
     UNAUTHENTICATED,
-    /** The caller does not have permission to execute the specified operation. */
+    /**
+     * The caller does not have permission to execute the specified operation. Clients should not
+     * retry this request unless advised otherwise.
+     */
     UNAUTHORIZED,
     /**
      * The requested resource could not be found but may be available in the future. Subsequent
-     * requests by the client are permissible.
+     * requests by the client are permissible but not advised.
      */
     NOT_FOUND,
     /**
      * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
-     * is out of space.
+     * is out of space. Subsequent requests by the client are permissible.
      */
     RESOURCE_EXHAUSTED,
-    /** An internal error occurred */
+    /** An internal error occurred. Subsequent requests by the client are permissible. */
     INTERNAL,
     /**
      * The server either does not recognize the request method, or it lacks the ability to fulfill
-     * the request.
+     * the request. Clients should not retry this request unless advised otherwise.
      */
     NOT_IMPLEMENTED,
-    /**
-     * The server either does not recognize the request method, or it lacks the ability to fulfill
-     * the request.
-     */
+    /** The service is currently unavailable. Subsequent requests by the client are permissible. */
     UNAVAILABLE,
-    /** Used by gateways to report that a request to an upstream server has timed out. */
+    /**
+     * Used by gateways to report that a request to an upstream server has timed out. Subsequent
+     * requests by the client are permissible.
+     */
     UPSTREAM_TIMEOUT
   }
 }

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/HeaderTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/HeaderTest.java
@@ -48,6 +48,13 @@ public class HeaderTest {
             HandlerException.RetryBehavior.RETRYABLE);
     assertTrue(he.isRetryable());
     assertEquals(HandlerException.RetryBehavior.RETRYABLE, he.getRetryBehavior());
+    // Verify that an unknown error type is retryable by default and the type is UNKNOWN
+    he =
+        new HandlerException("SOME_UNKNOWN_TYPE", null, HandlerException.RetryBehavior.UNSPECIFIED);
+    assertTrue(he.isRetryable());
+    assertEquals(HandlerException.RetryBehavior.UNSPECIFIED, he.getRetryBehavior());
+    assertEquals(HandlerException.ErrorType.UNKNOWN, he.getErrorType());
+    assertEquals("SOME_UNKNOWN_TYPE", he.getRawErrorType());
   }
 
   @Test

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/HeaderTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/HeaderTest.java
@@ -1,6 +1,6 @@
 package io.nexusrpc.handler;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import io.nexusrpc.Serializer;
 import java.io.ByteArrayInputStream;
@@ -20,6 +20,34 @@ public class HeaderTest {
             .build();
     // Verify that the map is case-insensitive
     verifyHeaders(context.getHeaders());
+  }
+
+  @Test
+  void retryHandlerException() {
+    // Verify that, by default, INTERNAL errors are retryable
+    HandlerException he = new HandlerException(HandlerException.ErrorType.INTERNAL, "message");
+    assertTrue(he.isRetryable());
+    assertEquals(HandlerException.RetryBehavior.UNSPECIFIED, he.getRetryBehavior());
+    // Verify that RetryBehavior.NON_RETRYABLE makes the error non-retryable
+    he =
+        new HandlerException(
+            HandlerException.ErrorType.INTERNAL,
+            "message",
+            HandlerException.RetryBehavior.NON_RETRYABLE);
+    assertFalse(he.isRetryable());
+    assertEquals(HandlerException.RetryBehavior.NON_RETRYABLE, he.getRetryBehavior());
+    // Verify that, by default, BAD_REQUEST errors are retryable
+    he = new HandlerException(HandlerException.ErrorType.BAD_REQUEST, "message");
+    assertFalse(he.isRetryable());
+    assertEquals(HandlerException.RetryBehavior.UNSPECIFIED, he.getRetryBehavior());
+    // Verify that RetryBehavior.RETRYABLE makes the error non-retryable
+    he =
+        new HandlerException(
+            HandlerException.ErrorType.BAD_REQUEST,
+            "message",
+            HandlerException.RetryBehavior.RETRYABLE);
+    assertTrue(he.isRetryable());
+    assertEquals(HandlerException.RetryBehavior.RETRYABLE, he.getRetryBehavior());
   }
 
   @Test


### PR DESCRIPTION
Add an optional Nexus-Request-Retryable header to the spec to allow handlers to override the default retry behavior of handler errors. And a recommendation for when to retry every handler error.

see also: https://github.com/nexus-rpc/api/pull/15