### PR TITLE
Add deadline to context

### DIFF
--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/Handler.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/Handler.java
@@ -1,9 +1,9 @@
 package io.nexusrpc.handler;
 
+import io.nexusrpc.Experimental;
 import io.nexusrpc.OperationException;
 import io.nexusrpc.OperationInfo;
 import io.nexusrpc.OperationStillRunningException;
-import io.nexusrpc.Experimental;
 
 /** Top-level handler for service calls. */
 public interface Handler {

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerResultContent.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerResultContent.java
@@ -1,10 +1,9 @@
 package io.nexusrpc.handler;
 
+import io.nexusrpc.Experimental;
 import java.io.InputStream;
 import java.util.*;
 import java.util.stream.Collectors;
-
-import io.nexusrpc.Experimental;
 import org.jspecify.annotations.Nullable;
 
 /** Content that can be fixed or streaming as a result of an operation. */

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationFetchInfoDetails.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationFetchInfoDetails.java
@@ -1,8 +1,7 @@
 package io.nexusrpc.handler;
 
-import java.util.Objects;
-
 import io.nexusrpc.Experimental;
+import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 /** Details for handling operation fetch info. */

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
@@ -5,12 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import io.nexusrpc.Link;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Instant;
 import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class OperationContextTest {
   @Test
-  void LinkTest() throws URISyntaxException {
+  void linkTest() throws URISyntaxException {
     OperationContext octx =
         OperationContext.newBuilder().setService("service").setOperation("operation").build();
     URI url = new URI("http://somepath?k=v");
@@ -20,5 +21,17 @@ public class OperationContextTest {
         Arrays.asList(Link.newBuilder().setUri(url).setType("com.example.MyResource").build()));
     octx.setLinks();
     assertEquals(octx.getLinks(), Arrays.asList());
+  }
+
+  @Test
+  void deadlineTest() {
+    Instant deadline = Instant.now().plusMillis(1000);
+    OperationContext octx =
+        OperationContext.newBuilder()
+            .setService("service")
+            .setOperation("operation")
+            .setDeadline(deadline)
+            .build();
+    assertEquals(deadline, octx.getDeadline());
   }
 }


### PR DESCRIPTION
Add deadline to context, this will be useful when we add `fetchResult` since the timeout there should be bounded by the remaining deadline.

closes https://github.com/nexus-rpc/sdk-java/issues/33