### PR TITLE
Add ServiceDefinition to OperationContext

### DIFF
--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
@@ -153,13 +153,15 @@ public class OperationContext {
         && Objects.equals(operation, that.operation)
         && Objects.equals(headers, that.headers)
         && Objects.equals(methodCanceller, that.methodCanceller)
+        && Objects.equals(deadline, that.deadline)
         && Objects.equals(links, that.links)
         && Objects.equals(serviceDefinition, that.serviceDefinition);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(service, operation, headers, methodCanceller, links, serviceDefinition);
+    return Objects.hash(
+        service, operation, headers, methodCanceller, deadline, links, serviceDefinition);
   }
 
   @Override
@@ -175,6 +177,8 @@ public class OperationContext {
         + headers
         + ", methodCanceller="
         + methodCanceller
+        + ", deadline="
+        + deadline
         + ", links="
         + links
         + ", serviceDefinition="
@@ -245,6 +249,7 @@ public class OperationContext {
       return this;
     }
 
+    /** Sets the service definition. */
     public Builder setServiceDefinition(ServiceDefinition serviceDefinition) {
       this.serviceDefinition = serviceDefinition;
       return this;

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
@@ -1,8 +1,8 @@
 package io.nexusrpc.handler;
 
 import io.nexusrpc.Link;
-import java.time.Instant;
 import io.nexusrpc.ServiceDefinition;
+import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/OperationContext.java
@@ -24,8 +24,8 @@ public class OperationContext {
   private final Map<String, String> headers;
   // This is not included in equals, hashCode, or toString
   private final @Nullable OperationMethodCanceller methodCanceller;
-  private final List<Link> links = new ArrayList<>();
   private final Instant deadline;
+  private final List<Link> links;
   private final @Nullable ServiceDefinition serviceDefinition;
 
   private OperationContext(
@@ -34,13 +34,15 @@ public class OperationContext {
       Map<String, String> headers,
       @Nullable OperationMethodCanceller methodCanceller,
       Instant deadline,
-      @Nullable ServiceDefinition serviceDefinition) {
+      @Nullable ServiceDefinition serviceDefinition,
+      List<Link> links) {
     this.service = service;
     this.operation = operation;
     this.headers = headers;
     this.methodCanceller = methodCanceller;
     this.deadline = deadline;
     this.serviceDefinition = serviceDefinition;
+    this.links = links;
   }
 
   /** Service name for the call. */
@@ -188,9 +190,14 @@ public class OperationContext {
     private @Nullable OperationMethodCanceller methodCanceller;
     private @Nullable Instant deadline;
     private @Nullable ServiceDefinition serviceDefinition;
+    // Currently links are not set in the builder, but they need to be passed though to go from
+    // OperationContext -> Builder
+    // and back to OperationContext, so we keep them here.
+    private final List<Link> links;
 
     private Builder() {
       headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+      links = new ArrayList<>();
     }
 
     private Builder(OperationContext context) {
@@ -200,6 +207,7 @@ public class OperationContext {
       methodCanceller = context.methodCanceller;
       deadline = context.deadline;
       serviceDefinition = context.serviceDefinition;
+      links = context.links;
     }
 
     /** Set service. Required. */
@@ -260,7 +268,8 @@ public class OperationContext {
           Collections.unmodifiableMap(new TreeMap<>(normalizedHeaders)),
           methodCanceller,
           deadline,
-          serviceDefinition);
+          serviceDefinition,
+          links);
     }
   }
 }

--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/ServiceHandler.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/ServiceHandler.java
@@ -67,8 +67,12 @@ public class ServiceHandler implements Handler {
     if (handler == null) {
       throw newUnrecognizedOperationException(context.getService(), context.getOperation());
     }
+    // Populate the service definition in the context so that the handler can use it
+    OperationContext contextWithServiceDef =
+        OperationContext.newBuilder(context).setServiceDefinition(instance.getDefinition()).build();
+
     OperationHandler<Object, Object> interceptedHandler =
-        interceptOperationHandler(context, handler);
+        interceptOperationHandler(contextWithServiceDef, handler);
     OperationDefinition definition =
         instance.getDefinition().getOperations().get(context.getOperation());
 
@@ -84,7 +88,8 @@ public class ServiceHandler implements Handler {
     }
 
     // Invoke handler
-    OperationStartResult<?> result = interceptedHandler.start(context, details, inputObject);
+    OperationStartResult<?> result =
+        interceptedHandler.start(contextWithServiceDef, details, inputObject);
 
     // If the result is an async result we can just return, but if it's a sync result we need to
     // serialize back out to bytes
@@ -108,7 +113,13 @@ public class ServiceHandler implements Handler {
     if (handler == null) {
       throw newUnrecognizedOperationException(context.getService(), context.getOperation());
     }
-    Object result = interceptOperationHandler(context, handler).fetchResult(context, details);
+    // Populate the service definition in the context so that the handler can use it
+    OperationContext contextWithServiceDef =
+        OperationContext.newBuilder(context).setServiceDefinition(instance.getDefinition()).build();
+
+    Object result =
+        interceptOperationHandler(contextWithServiceDef, handler)
+            .fetchResult(contextWithServiceDef, details);
     return resultToContent(result);
   }
 
@@ -136,7 +147,11 @@ public class ServiceHandler implements Handler {
     if (handler == null) {
       throw newUnrecognizedOperationException(context.getService(), context.getOperation());
     }
-    return interceptOperationHandler(context, handler).fetchInfo(context, details);
+    // Populate the service definition in the context so that the handler can use it
+    OperationContext contextWithServiceDef =
+        OperationContext.newBuilder(context).setServiceDefinition(instance.getDefinition()).build();
+    return interceptOperationHandler(contextWithServiceDef, handler)
+        .fetchInfo(contextWithServiceDef, details);
   }
 
   @Override
@@ -150,7 +165,11 @@ public class ServiceHandler implements Handler {
     if (handler == null) {
       throw newUnrecognizedOperationException(context.getService(), context.getOperation());
     }
-    interceptOperationHandler(context, handler).cancel(context, details);
+    // Populate the service definition in the context so that the handler can use it
+    OperationContext contextWithServiceDef =
+        OperationContext.newBuilder(context).setServiceDefinition(instance.getDefinition()).build();
+    interceptOperationHandler(contextWithServiceDef, handler)
+        .cancel(contextWithServiceDef, details);
   }
 
   private static HandlerException newUnrecognizedOperationException(

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
@@ -49,7 +49,7 @@ public class OperationContextTest {
   void contextBuilderTest() {
     OperationMethodCanceller omc = new OperationMethodCanceller();
     ServiceImplInstance serviceImpl = ServiceImplInstance.fromInstance(new IntegerServiceImpl());
-        Instant deadline = Instant.now().plusMillis(1000);
+    Instant deadline = Instant.now().plusMillis(1000);
     OperationContext octx =
         OperationContext.newBuilder()
             .setService("service")

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
@@ -46,7 +46,7 @@ public class OperationContextTest {
   }
 
   @Test
-  void contextBuilderTest() {
+  void contextBuilderTest() throws URISyntaxException {
     OperationMethodCanceller omc = new OperationMethodCanceller();
     ServiceImplInstance serviceImpl = ServiceImplInstance.fromInstance(new IntegerServiceImpl());
     Instant deadline = Instant.now().plusMillis(1000);

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
@@ -3,6 +3,7 @@ package io.nexusrpc.handler;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.nexusrpc.Link;
+import io.nexusrpc.example.TestServices;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Instant;
@@ -10,6 +11,15 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class OperationContextTest {
+
+  @ServiceImpl(service = TestServices.IntegerService.class)
+  public class IntegerServiceImpl {
+    @OperationImpl
+    public OperationHandler<Integer, Integer> operation() {
+      return OperationHandler.sync((ctx, details, input) -> 0);
+    }
+  }
+
   @Test
   void linkTest() throws URISyntaxException {
     OperationContext octx =
@@ -33,5 +43,23 @@ public class OperationContextTest {
             .setDeadline(deadline)
             .build();
     assertEquals(deadline, octx.getDeadline());
+  }
+
+  @Test
+  void contextBuilderTest() {
+    OperationMethodCanceller omc = new OperationMethodCanceller();
+    ServiceImplInstance serviceImpl = ServiceImplInstance.fromInstance(new IntegerServiceImpl());
+        Instant deadline = Instant.now().plusMillis(1000);
+    OperationContext octx =
+        OperationContext.newBuilder()
+            .setService("service")
+            .setOperation("operation")
+            .setDeadline(deadline)
+            .putHeader("key", "value")
+            .setMethodCanceller(omc)
+            .setServiceDefinition(serviceImpl.getDefinition())
+            .build();
+
+    assertEquals(octx, OperationContext.newBuilder(octx).build());
   }
 }

--- a/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
+++ b/nexus-sdk/src/test/java/io/nexusrpc/handler/OperationContextTest.java
@@ -59,7 +59,8 @@ public class OperationContextTest {
             .setMethodCanceller(omc)
             .setServiceDefinition(serviceImpl.getDefinition())
             .build();
-
+    URI url = new URI("http://somepath?k=v");
+    octx.setLinks(Link.newBuilder().setUri(url).setType("com.example.MyResource").build());
     assertEquals(octx, OperationContext.newBuilder(octx).build());
   }
 }


### PR DESCRIPTION
Add `ServiceDefinition` to `OperationContext`, this is needed for generic operation handlers