### PR TITLE
Add CONFLICT and REQUEST_TIMEOUT handler error types

### DIFF
--- a/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerException.java
+++ b/nexus-sdk/src/main/java/io/nexusrpc/handler/HandlerException.java
@@ -144,7 +144,7 @@ public class HandlerException extends RuntimeException {
      * client provided {@code Request-Timeout} or for any arbitrary reason such as enforcing some
      * configurable limit. Subsequent requests by the client are permissible.
      */
-    REQUEST_TIMEOUT
+    REQUEST_TIMEOUT,
     /**
      * Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file system
      * is out of space. Subsequent requests by the client are permissible.


### PR DESCRIPTION
## Description

- Add CONFLICT and REQUEST_TIMEOUT handler error types.
- Update isRetryable() method to handle new error types correctly:
  - CONFLICT: Non-retryable by default;
  - REQUEST_TIMEOUT: Retryable by default.

Fixes #37